### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Output Gradle Version
         id: version
         run: |
-          echo "version=$(./gradlew printVersion --console=plain | head -n 3 | tail -1)" >> $GITHUB_OUTPUT
+          echo "version=$(./gradlew --console=plain -q printVersion)" >> $GITHUB_OUTPUT
   build-image:
     name: Build Image
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,59 @@
+
+name: Release
+on:
+  release:
+   types:
+    - published
+jobs:
+  # step 1) take the sha we are on, and push a tag matching the release name
+  promote_tag:
+    name: 'Promote Tag'
+    timeout-minutes: 7
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # get the associated sha
+      - name: Get Existing Tag
+        run: echo "tag=sha-$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+        id: current-tag
+      # login to the registry
+      - name: Log into registry
+        timeout-minutes: 5
+        uses: docker/login-action@a5609cb39f57be157c39b77359abfaa43aeaeb8f
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+      # retag, this is same repo but could be tweaked to push to a prod repo
+      - name: Promote Tag
+        run: |
+            skopeo copy docker://ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ steps.current-tag.outputs.tag }} \
+                docker://ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.event.release.tag_name }}
+  # step 2) build and publish the helm chart to an oci repo.
+  publish_chart:
+    name: 'Publish Chart'
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 7
+    needs:
+      - promote_tag
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # login to the registry for oci pushes
+      - name: Log into registry
+        timeout-minutes: 5
+        uses: docker/login-action@a5609cb39f57be157c39b77359abfaa43aeaeb8f
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+      # use gradle tasks to build, and publish chart
+      - name: Execute Gradle Tasks
+        uses: gradle/gradle-build-action@v2.8.0
+        with:
+            gradle-version: 8.3
+            arguments: k8sResource k8sHelm  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,10 +36,8 @@ jobs:
       - name: Output Gradle Version
         id: version
         run: |
-          echo "Gradle version output"
-          ./gradlew printVersion --console=plain
-          echo "New version will be $(./gradlew printVersion --console=plain | head -n 3 | tail -1)"
-          echo "version=$(./gradlew printVersion --console=plain | head -n 3 | tail -1)" >> $GITHUB_OUTPUT
+          echo "New version will be $(./gradlew --console=plain -q printVersion)"
+          echo "version=$(./gradlew --console=plain -q printVersion | head -n 3 | tail -1)" >> $GITHUB_OUTPUT
       # retag, this is same repo but could be tweaked to push to a prod repo
       - name: Promote Tag
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
       - name: Output Gradle Version
         id: version
         run: |
+          echo "Gradle version output"
+          ./gradlew printVersion --console=plain
           echo "New version will be $(./gradlew printVersion --console=plain | head -n 3 | tail -1)"
           echo "version=$(./gradlew printVersion --console=plain | head -n 3 | tail -1)" >> $GITHUB_OUTPUT
       # retag, this is same repo but could be tweaked to push to a prod repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+            distribution: "zulu"
+            java-version: "17"
       # get the associated sha
       - name: Get Existing Tag
         run: echo "tag=sha-$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
@@ -27,11 +31,17 @@ jobs:
             registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
+      # get the version from gradle, this is used in the chart
+      # we need to ensure this tag exists before publishing the chart
+      - name: Output Gradle Version
+        id: version
+        run: |
+          echo "version=$(./gradlew printVersion --console=plain | head -n 3 | tail -1)" >> $GITHUB_OUTPUT
       # retag, this is same repo but could be tweaked to push to a prod repo
       - name: Promote Tag
         run: |
             skopeo copy docker://ghcr.io/${{ github.repository }}:${{ steps.current-tag.outputs.tag }} \
-                docker://ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+                docker://ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }} 
   # step 2) build and publish the helm chart to an oci repo.
   publish_chart:
     name: 'Publish Chart'
@@ -43,6 +53,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+            distribution: "zulu"
+            java-version: "17"
       # login to the registry for oci pushes
       - name: Log into registry
         timeout-minutes: 5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,7 @@ jobs:
       - name: Output Gradle Version
         id: version
         run: |
+          echo "New version will be $(./gradlew printVersion --console=plain | head -n 3 | tail -1)"
           echo "version=$(./gradlew printVersion --console=plain | head -n 3 | tail -1)" >> $GITHUB_OUTPUT
       # retag, this is same repo but could be tweaked to push to a prod repo
       - name: Promote Tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,8 @@ jobs:
       # retag, this is same repo but could be tweaked to push to a prod repo
       - name: Promote Tag
         run: |
-            skopeo copy docker://ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ steps.current-tag.outputs.tag }} \
-                docker://ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.event.release.tag_name }}
+            skopeo copy docker://ghcr.io/${{ github.repository }}:${{ steps.current-tag.outputs.tag }} \
+                docker://ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
   # step 2) build and publish the helm chart to an oci repo.
   publish_chart:
     name: 'Publish Chart'
@@ -56,4 +56,4 @@ jobs:
         uses: gradle/gradle-build-action@v2.8.0
         with:
             gradle-version: 8.3
-            arguments: k8sResource k8sHelm  
+            arguments: k8sResource k8sHelm k8sHelmPush


### PR DESCRIPTION
What
---
Adds a release workflow trigger on release creation that promotes the matched sha image tag to the associated release tag and publishes the helm chart at the same version tag.